### PR TITLE
Fix optimization

### DIFF
--- a/src/mammos_analysis/kuzmin.py
+++ b/src/mammos_analysis/kuzmin.py
@@ -105,7 +105,7 @@ def kuzmin_properties(
 
     if Tc is None:
         optimize_Tc = True
-        init_guess = [400, 0.5]
+        init_guess = [T.value[1], 0.5]
         bounds = ([0, 0], [np.inf, np.inf])
     else:
         Tc = Tc.value.flatten()[0] if Tc.value.ndim > 0 else Tc.value

--- a/src/mammos_analysis/kuzmin.py
+++ b/src/mammos_analysis/kuzmin.py
@@ -182,10 +182,13 @@ def kuzmin_formula(Ms_0, T_c, s, T):
     if isinstance(T, me.Entity):
         T = T.value
     base = 1 - s * (T / T_c) ** 1.5 - (1 - s) * (T / T_c) ** 2.5
-    out = np.zeros_like(T, dtype=np.float64)
-    # only compute base**(1/3) where T < T_c; elsewhere leave as zero
-    np.power(base, 1 / 3, out=out, where=(T_c > T))
-    return Ms_0 * out
+    base = np.array(base)  # we make sure that it is a numpy.ndarray
+    pos = np.zeros_like(base, dtype=np.float64)
+    neg = np.zeros_like(base, dtype=np.float64)
+    np.power(base, 1 / 3, out=pos, where=np.logical_and(T_c > T, base > 0))
+    np.power(-base, 1 / 3, out=neg, where=np.logical_and(T_c > T, base < 0))
+    # both pos and neg will be zero when T >= T_c
+    return Ms_0 * (pos - neg)
 
 
 class _A_function_of_temperature:

--- a/src/mammos_analysis/kuzmin.py
+++ b/src/mammos_analysis/kuzmin.py
@@ -183,12 +183,9 @@ def kuzmin_formula(Ms_0, T_c, s, T):
         T = T.value
     base = 1 - s * (T / T_c) ** 1.5 - (1 - s) * (T / T_c) ** 2.5
     base = np.array(base)  # we make sure that it is a numpy.ndarray
-    pos = np.zeros_like(base, dtype=np.float64)
-    neg = np.zeros_like(base, dtype=np.float64)
-    np.power(base, 1 / 3, out=pos, where=np.logical_and(T_c > T, base > 0))
-    np.power(-base, 1 / 3, out=neg, where=np.logical_and(T_c > T, base < 0))
-    # both pos and neg will be zero when T >= T_c
-    return Ms_0 * (pos - neg)
+    out = np.zeros_like(base, dtype=np.float64)
+    np.cbrt(base, out=out, where=T_c > T)
+    return Ms_0 * out
 
 
 class _A_function_of_temperature:

--- a/tests/test_kuzmin.py
+++ b/tests/test_kuzmin.py
@@ -254,3 +254,21 @@ def test_kuzmin_properties_no_Ms_0():
     with pytest.raises(ValueError):
         # This test will fail as there is no data on Ms_0
         kuzmin_properties(Ms=Ms_data, T=T_data, K1_0=K1_0, Tc=Tc)
+
+def test_kuzmin_low_Tc():
+    """Test the kuzmin_properties function to retrieve a low Tc value."""
+    T_data = me.Entity(
+        "ThermodynamicTemperature",
+        np.linspace(0, 500, 50)
+    )
+    Ms_data = me.Ms(
+        kuzmin_formula(
+            Ms_0=me.Ms(100),
+            T_c=me.Tc(value=100, unit="K"),
+            s=0.75,
+            T=T_data
+        )
+    )
+    result = kuzmin_properties(Ms=Ms_data, T=T_data)
+    assert result.Tc == me.Tc(100)
+    assert math.isclose(result.s, 0.75, rel_tol=1e-02)

--- a/tests/test_kuzmin.py
+++ b/tests/test_kuzmin.py
@@ -1,5 +1,7 @@
 """Tests for Kuzmin functions."""
 
+import math
+
 import mammos_entity as me
 import mammos_units as u
 import numpy as np
@@ -158,7 +160,7 @@ def test_kuzmin_properties_all_info():
     assert isinstance(result.s, u.Quantity)
     assert result.Tc == Tc
     assert result.K1(0) == K1_0
-    assert np.allclose(result.s, 0.75)
+    assert math.isclose(result.s, 0.75, rel_tol=1e-02)
     assert result.Ms(T_data) == Ms_data
     assert result.Ms(0) == Ms_0
     A_0 = me.A(
@@ -226,7 +228,7 @@ def test_kuzmin_properties_no_Tc():
     assert isinstance(result.s, u.Quantity)
     assert result.Tc == Tc
     assert result.K1(0) == K1_0
-    assert np.allclose(result.s, 0.75)
+    assert math.isclose(result.s, 0.75, rel_tol=1e-02)
     assert result.Ms(T_data) == Ms_data
     assert result.Ms(0) == Ms_0
 

--- a/tests/test_kuzmin.py
+++ b/tests/test_kuzmin.py
@@ -255,18 +255,13 @@ def test_kuzmin_properties_no_Ms_0():
         # This test will fail as there is no data on Ms_0
         kuzmin_properties(Ms=Ms_data, T=T_data, K1_0=K1_0, Tc=Tc)
 
+
 def test_kuzmin_low_Tc():
     """Test the kuzmin_properties function to retrieve a low Tc value."""
-    T_data = me.Entity(
-        "ThermodynamicTemperature",
-        np.linspace(0, 500, 50)
-    )
+    T_data = me.Entity("ThermodynamicTemperature", np.linspace(0, 500, 50))
     Ms_data = me.Ms(
         kuzmin_formula(
-            Ms_0=me.Ms(100),
-            T_c=me.Tc(value=100, unit="K"),
-            s=0.75,
-            T=T_data
+            Ms_0=me.Ms(100), T_c=me.Tc(value=100, unit="K"), s=0.75, T=T_data
         )
     )
     result = kuzmin_properties(Ms=Ms_data, T=T_data)


### PR DESCRIPTION
`np.power(base, 1 / 3, out=out, where=(T_c > T)` was not good. This was completely ignoring all those curves with negative values and assigning zero values instead. I know that negative magnetisation has no physical meaning, but [assigning `nan` to cubic roots of negative numbers](https://numpy.org/doc/2.1/reference/generated/numpy.power.html) has no mathematical meaning instead. This was the reason why so many `nan` were created, and why they would then appear to the least squares Jacobian.

At first I thought the problem was in a starting Tc that is too high. This is actually not a problem when there is enough data. It is true that with low data there is less information and more local minima. So starting from high Tc and with few data points the optimization does stop there.

But with enough data points this is solved. To be sure anyway, we have to start from an initial guess for Tc that is low enough. The minimum it can be is the **second value of `T_data`**.
Note that between the first value and the second value of `T_data` the optimization function is flat, and therefore in that region the optimization would fail immediately. The second value is in my opinion a safe enough choice.

Fix #16 .