### PR TITLE
update docstrings and create aliases for N_dem

### DIFF
--- a/src/mammos_analysis/demag.py
+++ b/src/mammos_analysis/demag.py
@@ -1,4 +1,4 @@
-"""Functions calculating demagnetization factors."""
+"""Functions calculating demagnetizing factors."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ def demag_cuboid(
     x2: mammos_entity.Entity | astropy.units.Quantity | numpy.ndarray,
     x3: mammos_entity.Entity | astropy.units.Quantity | numpy.ndarray,
 ) -> mammos_entity.Entity:
-    """Calculate demagnetization factors of a rectangular cuboid.
+    """Calculate demagnetizing factors of a rectangular cuboid.
 
     Equation 1 from A. Aharoni, J. Appl. Phys. 83, 3422 (1998).
     https://doi.org/10.1063/1.367113
@@ -29,8 +29,8 @@ def demag_cuboid(
         x3: Full side length of rectangular cuboid in direction 3
 
     Returns:
-        Demagnetizing factors along each dimension. Order of dimensions is the
-        same as for input arguments.
+        :entity:`DemagnetizingFactor` along each dimension. Order of dimensions
+        is the same as for input arguments.
 
     Raises:
         ValueError: If arguments with and without unit are mixed.

--- a/src/mammos_analysis/hysteresis.py
+++ b/src/mammos_analysis/hysteresis.py
@@ -232,7 +232,12 @@ def extract_B_curve(
     M: mammos_entity.Entity | mammos_units.Quantity | numpy.typing.ArrayLike,
     demagnetization_coefficient: float,
 ) -> mammos_entity.Entity:
-    """Compute the B–H curve from a hysteresis loop.
+    r"""Compute the B–H curve from a hysteresis loop.
+
+    The internal field and flux density are computed as
+    :math:`H_{int} = H - N_{dem} M` and
+    :math:`B_{int} = \mu_0 (H_{int} + M)`, where :math:`N_{dem}` is the
+    demagnetization coefficient.
 
     Args:
         H: :entity:`ExternalMagneticField`.
@@ -259,8 +264,10 @@ def extract_B_curve(
     # TODO the doctest should use the following line but that sometimes
     # fails on Mac and/or Windows
     # MagneticFluxDensity(value=..., unit=T)
-    if isinstance(demagnetization_coefficient, int | float):
-        if demagnetization_coefficient < 0 or demagnetization_coefficient > 1:
+
+    N_dem = demagnetization_coefficient
+    if isinstance(N_dem, int | float):
+        if N_dem < 0 or N_dem > 1:
             raise ValueError("Demagnetization coefficient must be between 0 and 1.")
     else:
         raise ValueError("Demagnetization coefficient must be a float or int.")
@@ -277,7 +284,7 @@ def extract_B_curve(
     )
 
     # Calculate internal field and flux density
-    H_internal = H.q - demagnetization_coefficient * M.q
+    H_internal = H.q - N_dem * M.q
     B_internal = (H_internal + M.q) * u.constants.mu0
 
     return me.Entity("MagneticFluxDensity", value=B_internal)
@@ -309,11 +316,16 @@ def extract_BHmax(
     M: mammos_entity.Entity | mammos_units.Quantity | numpy.typing.ArrayLike,
     demagnetization_coefficient: float,
 ) -> mammos_entity.Entity:
-    """Determine the maximum energy product from a hysteresis loop.
+    r"""Determine the maximum energy product from a hysteresis loop.
 
-    Computes internal fields H_int and B_int from H and M using
-    the demagnetization_coefficient. H and M provide array data
-    for a half-hysteresis loop.
+    Computes internal fields H_int and B_int from H and M using the
+    demagnetization_coefficient. H and M provide array data for a
+    half-hysteresis loop.
+
+    The internal field and flux density are computed as
+    :math:`H_{int} = H - N_{dem} M` and
+    :math:`B_{int} = \mu_0 (H_{int} + M)`, where :math:`N_{dem}` is the
+    demagnetization coefficient.
 
     Args:
         H: :entity:`ExternalMagneticField`.
@@ -351,6 +363,7 @@ def extract_BHmax(
 
     H = H.q
     M = M.q
+    N_dem = demagnetization_coefficient
 
     assert len(H) == len(M)
 
@@ -365,7 +378,7 @@ def extract_BHmax(
         M = M[::-1]
 
     # Calculate internal field and flux density
-    H_internal = H - demagnetization_coefficient * M
+    H_internal = H - N_dem * M
     B_internal = (H_internal + M) * u.constants.mu0
 
     # only consider values in 2nd quadrant
@@ -416,11 +429,9 @@ def extrinsic_properties(
     """
     Hc = extract_coercive_field(H, M)
     Mr = extract_remanent_magnetization(H, M)
+    N_dem = demagnetization_coefficient
 
-    if demagnetization_coefficient is None:
-        BHmax = me.BHmax(np.nan)
-    else:
-        BHmax = extract_BHmax(H, M, demagnetization_coefficient)
+    BHmax = me.BHmax(np.nan) if N_dem is None else extract_BHmax(H, M, N_dem)
 
     return ExtrinsicProperties(
         Hc=me.Hc(Hc),

--- a/src/mammos_analysis/hysteresis.py
+++ b/src/mammos_analysis/hysteresis.py
@@ -264,10 +264,8 @@ def extract_B_curve(
     # TODO the doctest should use the following line but that sometimes
     # fails on Mac and/or Windows
     # MagneticFluxDensity(value=..., unit=T)
-
-    N_dem = demagnetization_coefficient
-    if isinstance(N_dem, int | float):
-        if N_dem < 0 or N_dem > 1:
+    if isinstance(demagnetization_coefficient, int | float):
+        if demagnetization_coefficient < 0 or demagnetization_coefficient > 1:
             raise ValueError("Demagnetization coefficient must be between 0 and 1.")
     else:
         raise ValueError("Demagnetization coefficient must be a float or int.")
@@ -284,7 +282,7 @@ def extract_B_curve(
     )
 
     # Calculate internal field and flux density
-    H_internal = H.q - N_dem * M.q
+    H_internal = H.q - demagnetization_coefficient * M.q
     B_internal = (H_internal + M.q) * u.constants.mu0
 
     return me.Entity("MagneticFluxDensity", value=B_internal)
@@ -363,7 +361,6 @@ def extract_BHmax(
 
     H = H.q
     M = M.q
-    N_dem = demagnetization_coefficient
 
     assert len(H) == len(M)
 
@@ -378,7 +375,7 @@ def extract_BHmax(
         M = M[::-1]
 
     # Calculate internal field and flux density
-    H_internal = H - N_dem * M
+    H_internal = H - demagnetization_coefficient * M
     B_internal = (H_internal + M) * u.constants.mu0
 
     # only consider values in 2nd quadrant
@@ -429,9 +426,12 @@ def extrinsic_properties(
     """
     Hc = extract_coercive_field(H, M)
     Mr = extract_remanent_magnetization(H, M)
-    N_dem = demagnetization_coefficient
 
-    BHmax = me.BHmax(np.nan) if N_dem is None else extract_BHmax(H, M, N_dem)
+    BHmax = (
+        me.BHmax(np.nan)
+        if demagnetization_coefficient is None
+        else extract_BHmax(H, M, demagnetization_coefficient)
+    )
 
     return ExtrinsicProperties(
         Hc=me.Hc(Hc),

--- a/src/mammos_analysis/hysteresis.py
+++ b/src/mammos_analysis/hysteresis.py
@@ -237,14 +237,14 @@ def extract_B_curve(
     The internal field and flux density are computed as
     :math:`H_{int} = H - N_{dem} M` and
     :math:`B_{int} = \mu_0 (H_{int} + M)`, where :math:`N_{dem}` is the
-    demagnetization coefficient.
+    demagnetizing factor.
 
     Args:
         H: :entity:`ExternalMagneticField`.
             If no unit is provided, values are interpreted as 'A / m'.
         M: :entity:`Magnetization`.
             If no unit is provided, values are interpreted as 'A / m'.
-        demagnetization_coefficient: Demagnetization coefficient (0 to 1).
+        demagnetization_coefficient: Demagnetizing factor (0 to 1).
 
     Returns:
         :entity:`MagneticFluxDensity`.
@@ -266,9 +266,9 @@ def extract_B_curve(
     # MagneticFluxDensity(value=..., unit=T)
     if isinstance(demagnetization_coefficient, int | float):
         if demagnetization_coefficient < 0 or demagnetization_coefficient > 1:
-            raise ValueError("Demagnetization coefficient must be between 0 and 1.")
+            raise ValueError("Demagnetizing factor must be between 0 and 1.")
     else:
-        raise ValueError("Demagnetization coefficient must be a float or int.")
+        raise ValueError("Demagnetizing factor must be a float or int.")
 
     H = me._entity.from_compatible(
         "ExternalMagneticField", "A / m", H=H, enforce_unit=True
@@ -317,20 +317,20 @@ def extract_BHmax(
     r"""Determine the maximum energy product from a hysteresis loop.
 
     Computes internal fields H_int and B_int from H and M using the
-    demagnetization_coefficient. H and M provide array data for a
+    demagnetizing factor. H and M provide array data for a
     half-hysteresis loop.
 
     The internal field and flux density are computed as
     :math:`H_{int} = H - N_{dem} M` and
     :math:`B_{int} = \mu_0 (H_{int} + M)`, where :math:`N_{dem}` is the
-    demagnetization coefficient.
+    demagnetizing factor.
 
     Args:
         H: :entity:`ExternalMagneticField`.
             If no unit is provided, values are interpreted as 'A / m'.
         M: :entity:`Magnetization`.
             If no unit is provided, values are interpreted as 'A / m'.
-        demagnetization_coefficient: Demagnetization coefficient (0 to 1).
+        demagnetization_coefficient: Demagnetizing factor (0 to 1).
 
     Returns:
         :entity:`MaximumEnergyProduct`.
@@ -416,7 +416,7 @@ def extrinsic_properties(
             If no unit is provided, values are interpreted as 'A / m'.
         M: :entity:`Magnetization`.
             If no unit is provided, values are interpreted as 'A / m'.
-        demagnetization_coefficient: Demagnetization coefficient for BHmax.
+        demagnetization_coefficient: Demagnetizing factor for BHmax.
 
     Returns:
         ExtrinsicProperties containing Hc, Mr, and BHmax.

--- a/tests/test_hysteresis.py
+++ b/tests/test_hysteresis.py
@@ -327,7 +327,7 @@ def test_B_curve_errors():
     H = me.H(h_values * u.A / u.m)
     M = me.Ms(m_values * u.A / u.m)
 
-    # Test with invalid demagnetization coefficient
+    # Test with invalid demagnetizing factor
     with pytest.raises(ValueError):
         extract_B_curve(H, M, demagnetization_coefficient=None)
     with pytest.raises(ValueError):


### PR DESCRIPTION
closes #97 

This PR introduces the alias `N_dem` for `demagnetization_coefficient` in 'hysteresis.py`. Later this may be updated for the input arguments of corresponding functions. These changes are not done here, because it leads to changes in the API.