### PR TITLE
Add agent contribution instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions for mammos-analysis
+
+This file is only for AI coding agents. General package guidance belongs in
+`CONTRIBUTING.md`; shared MaMMoS standards belong in
+`CONTRIBUTING-MaMMoS.md`.
+
+Read `CONTRIBUTING.md`, `CONTRIBUTING-MaMMoS.md`, and `README.md` before editing.
+
+`CONTRIBUTING-MaMMoS.md` is a read-only package copy. Make edits to shared
+MaMMoS standards in the `mammos-devtools` repository instead.
+
+This repository must work as a standalone checkout. Do not assume
+`mammos-devtools` or sibling repositories are present. Use this repository's
+`pyproject.toml`, pixi tasks, tests, examples, and docs as the local source of
+truth unless explicitly instructed otherwise.
+
+If this checkout is located at `mammos-devtools/packages/mammos-analysis`, also
+read `../../AGENTS.md` for umbrella-repository guidance.
+
+Keep generated code and documentation simple, explicit, and easy for a human
+maintainer to understand.


### PR DESCRIPTION
## Summary

- add package-specific AI agent instructions in `AGENTS.md`
- tell agents to read `CONTRIBUTING.md`, `CONTRIBUTING-MaMMoS.md`, and `README.md` before editing
- clarify that package `CONTRIBUTING-MaMMoS.md` copies are read-only and shared standards edits belong in `mammos-devtools`
- add `CONTRIBUTING-MaMMoS.md` where the package was missing the shared standards file

## Validation

- pre-commit hooks ran during commit and passed for the staged documentation files
- verified each package has `CONTRIBUTING.md`
- verified each package has `CONTRIBUTING-MaMMoS.md`
- verified each package `AGENTS.md` references `CONTRIBUTING-MaMMoS.md` and marks it as a read-only package copy